### PR TITLE
Added a sass var which refers to image path, Allow empty prefix

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ CSSImage.prototype.normalize_folder = function(filepath, root){
 CSSImage.prototype.name = function(filepath, options){
   var postfix = options && options.postfix ? options.postfix : "";
   if(options && options.squeeze){ postfix += "-s" + options.squeeze; }
-  var prefix = options && options.prefix ? options.prefix : "img_";
+  var prefix = options && (typeof options.prefix !== "undefined") ? options.prefix : "img_";
   var separator = (options && options.separator) || "_";
   var filename = libpath.basename(filepath);
   var ext = libpath.extname(filepath);

--- a/index.js
+++ b/index.js
@@ -33,9 +33,12 @@ CSSImage.prototype.scss_vars = function(filepath, _width, _height, options){
   var squeeze = (options && !!options.squeeze) ? +options.squeeze : 1;
   var width = Math.floor(_width/squeeze);
   var height = Math.floor(_height/squeeze);
+  var root = (options && options.root) || "";
+  var retina = options && !!options.retina;
 
   return "$" + name + "__width: " + width + "px;\n" +
-         "$" + name + "__height: " + height + "px;\n";
+         "$" + name + "__height: " + height + "px;\n" +
+         "$" + name + "__path: " + this.normalize_path(filepath, root, retina) + ";\n";
 };
 
 CSSImage.prototype.scss_mixin = function(filepath, _width, _height, root, options){

--- a/test/main.js
+++ b/test/main.js
@@ -85,6 +85,15 @@ describe("test CSSImage", function(){
                  "}\n";
     c.css("test/images.jpg", 100, 110, "../images", {separator: "-", prefix:"img-"}).should.eql(result);
   });
+  it("test css with empty prefix", function(){
+    var result = ".test_images{\n" +
+                 "  width: 100px;\n" +
+                 "  height: 110px;\n" +
+                 "  background-image: url(../images/test/images.jpg);\n" +
+                 "  background-size: 100px 110px;\n" +
+                 "}\n";
+    c.css("test/images.jpg", 100, 110, "../images", {prefix:""}).should.eql(result);
+  });
   it("test css with retina", function(){
     var result = "@media (min-device-pixel-ratio: 2) and (min-resolution: 192dpi){\n" +
                  "  .img_test_images{\n" +
@@ -138,6 +147,15 @@ describe("test CSSImage", function(){
                  "}\n";
     c.scss_mixin("test/images.jpg", 100, 110, "../images", {squeeze:2}).should.eql(result);
   });
+  it("test scss_mixin with empty prefix", function(){
+    var result = "@mixin test_images(){\n" +
+                 "  width: 100px;\n"+
+                 "  height: 110px;\n"+
+                 "  background-image: url(../images/test/images.jpg);\n"+
+                 "  background-size: 100px 110px;\n"+
+                 "}\n";
+    c.scss_mixin("test/images.jpg", 100, 110, "../images", {prefix: ""}).should.eql(result);
+  });
 
   it("test scss_vars", function(){
     var result = "$img_test_images__width: 100px;\n" +
@@ -152,6 +170,10 @@ describe("test CSSImage", function(){
              "$img_test_images-s2__height: 55px;\n" +
              "$img_test_images-s2__path: test/images.jpg;\n";
     c.scss_vars("test/images.jpg", 100, 110, {squeeze:2}).should.eql(result);
+    result = "$test_images__width: 100px;\n" +
+             "$test_images__height: 110px;\n" +
+             "$test_images__path: test/images.jpg;\n";
+    c.scss_vars("test/images.jpg", 100, 110, {prefix:""}).should.eql(result);
   });
   it("test scss", function(){
     var result = "@mixin img_test_images(){\n" +

--- a/test/main.js
+++ b/test/main.js
@@ -141,13 +141,16 @@ describe("test CSSImage", function(){
 
   it("test scss_vars", function(){
     var result = "$img_test_images__width: 100px;\n" +
-                 "$img_test_images__height: 110px;\n";
+                 "$img_test_images__height: 110px;\n" +
+                 "$img_test_images__path: test/images.jpg;\n";
     c.scss_vars("test/images.jpg", 100, 110).should.eql(result);
     result = "$img_test_images-2x__width: 100px;\n" +
-             "$img_test_images-2x__height: 110px;\n";
+             "$img_test_images-2x__height: 110px;\n" +
+             "$img_test_images-2x__path: test/images.jpg;\n";
     c.scss_vars("test/images.jpg", 100, 110, {postfix:"-2x"}).should.eql(result);
     result = "$img_test_images-s2__width: 50px;\n" +
-             "$img_test_images-s2__height: 55px;\n";
+             "$img_test_images-s2__height: 55px;\n" +
+             "$img_test_images-s2__path: test/images.jpg;\n";
     c.scss_vars("test/images.jpg", 100, 110, {squeeze:2}).should.eql(result);
   });
   it("test scss", function(){
@@ -158,7 +161,8 @@ describe("test CSSImage", function(){
                  "  background-size: 100px 110px;\n"+
                  "}\n" +
                 "$img_test_images__width: 100px;\n" +
-                "$img_test_images__height: 110px;\n";
+                "$img_test_images__height: 110px;\n" +
+                "$img_test_images__path: test/images.jpg;\n";
     c.scss("test/images.jpg", 100, 110, "../images").should.eql(result);
     result = "@mixin img_test_images-2x(){\n" +
              "  width: 100px;\n"+
@@ -167,7 +171,8 @@ describe("test CSSImage", function(){
              "  background-size: 100px 110px;\n"+
              "}\n" +
             "$img_test_images-2x__width: 100px;\n" +
-            "$img_test_images-2x__height: 110px;\n";
+            "$img_test_images-2x__height: 110px;\n" +
+            "$img_test_images-2x__path: test/images.jpg;\n";
     c.scss("test/images.jpg", 100, 110, "../images", {postfix: "-2x"}).should.eql(result);
 
   });
@@ -185,7 +190,8 @@ describe("test CSSImage", function(){
                  "  }\n" +
                  "}\n" +
                 "$img_test_images__width: 100px;\n" +
-                "$img_test_images__height: 110px;\n";
+                "$img_test_images__height: 110px;\n" +
+                "$img_test_images__path: test/images-50pc.jpg;\n";
     c.scss("test/images.jpg", 100, 110, "../images", {retina: true}).should.eql(result);
   });
   it("test external api all args", function(){
@@ -224,6 +230,7 @@ describe("test CSSImage", function(){
       "}\n" +
       "$img_t__width: 400px;\n" +
       "$img_t__height: 300px;\n" +
+      "$img_t__path: root/t-50pc.png;\n" +
       "@mixin img_t-s2(){\n" +
       "  width: 200px;\n" +
       "  height: 150px;\n" +
@@ -231,7 +238,8 @@ describe("test CSSImage", function(){
       "  background-size: 200px 150px;\n" +
       "}\n" +
       "$img_t-s2__width: 200px;\n" +
-      "$img_t-s2__height: 150px;\n";
+      "$img_t-s2__height: 150px;\n" +
+      "$img_t-s2__path: root/t.png;\n";
 
     cssimage([{ width: 400, height: 300, file: "t.png"}],{
       css: true,
@@ -250,7 +258,8 @@ describe("test CSSImage", function(){
       "  background-size: 400px 300px;\n" +
       "}\n" +
       "$img_t__width: 400px;\n" +
-      "$img_t__height: 300px;\n";
+      "$img_t__height: 300px;\n" +
+      "$img_t__path: root/t.png;\n";
 
     cssimage([{ width: 400, height: 300, file: "t.png"}],{
       css: false,
@@ -346,6 +355,7 @@ describe("test CSSImage", function(){
       "}\n" +
       "$img_t__width: 400px;\n" +
       "$img_t__height: 300px;\n" +
+      "$img_t__path: root/t-50pc.png;\n" +
       "@mixin img_t-s2(){\n" +
       "  width: 200px;\n" +
       "  height: 150px;\n" +
@@ -353,7 +363,8 @@ describe("test CSSImage", function(){
       "  background-size: 200px 150px;\n" +
       "}\n" +
       "$img_t-s2__width: 200px;\n" +
-      "$img_t-s2__height: 150px;\n";
+      "$img_t-s2__height: 150px;\n" +
+      "$img_t-s2__path: root/t.png;\n";
 
     cssimage([{ width: 400, height: 300, file: "t.png"}],{
       scss: true,


### PR DESCRIPTION
Hello. thank you for this nice module.
Let me pull request for better use cases.

■1d1ed5d
Added one more sass var which refers to the image file path.
This path is the same as background-images one in mixin.
This change is because I want customize sass with images more flexibly like composing sprite.

■12757e5
This is just my preference.
I want use these sass vars with more shorter name. So I want to omit the prefix though I know it's not recommended.

Thank you for your time. Best regards.
